### PR TITLE
fix turtle syntax

### DIFF
--- a/mid-prog.ttl
+++ b/mid-prog.ttl
@@ -473,66 +473,66 @@ mid-prog:111 a mid:Program ;
     rdfs:seeAlso <http://dbpedia.org/resource/Shehnai> .
 
 mid-prog:112 a mid:Program ;
-    rdfs:label "Tinkle Bell" .
+    rdfs:label "Tinkle Bell" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Bell> .
 
 mid-prog:113 a mid:Program ;
-    rdfs:label "Agogo" .
+    rdfs:label "Agogo" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Agog%C3%B4> .
 
 mid-prog:114 a mid:Program ;
-    rdfs:label "Steel Drums" .
+    rdfs:label "Steel Drums" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Steelpan> .
 
 mid-prog:115 a mid:Program ;
-    rdfs:label "Woodblock" .
+    rdfs:label "Woodblock" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Wood_block> .
 
 mid-prog:116 a mid:Program ;
-    rdfs:label "Taiko Drum" .
+    rdfs:label "Taiko Drum" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Taiko> .
 
 mid-prog:117 a mid:Program ;
-    rdfs:label "Melodic Tom" .
+    rdfs:label "Melodic Tom" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Tom-tom_drum> .
 
 mid-prog:118 a mid:Program ;
-    rdfs:label "Synth Drum" .
+    rdfs:label "Synth Drum" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Electronic_drum> .
 
 mid-prog:119 a mid:Program ;
-    rdfs:label "Cymbal" .
+    rdfs:label "Cymbal" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Cymbal> .
 
 mid-prog:120 a mid:Program ;
-    rdfs:label "Guitar Fret Noise" .
+    rdfs:label "Guitar Fret Noise" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Guitar> ;
     rdfs:seeAlso <http://dbpedia.org/resource/Fret> .
 
 mid-prog:121 a mid:Program ;
-    rdfs:label "Breath Noise" .
+    rdfs:label "Breath Noise" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Breathing> .
 
 mid-prog:122 a mid:Program ;
-    rdfs:label "Seashore" .
+    rdfs:label "Seashore" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Coast> .
 
 mid-prog:123 a mid:Program ;
-    rdfs:label "Bird Tweet" .
+    rdfs:label "Bird Tweet" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Bird_vocalisation> .
 
 mid-prog:124 a mid:Program ;
-    rdfs:label "Telephone Ring" .
+    rdfs:label "Telephone Ring" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Ring_(telephone)> .
 
 mid-prog:125 a mid:Program ;
-    rdfs:label "Helicopter" .
+    rdfs:label "Helicopter" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Helicopter> .
 
 mid-prog:126 a mid:Program ;
-    rdfs:label "Applause" .
+    rdfs:label "Applause" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Applause> .
 
 mid-prog:127 a mid:Program ;
-    rdfs:label "Gunshot" .
+    rdfs:label "Gunshot" ;
     rdfs:seeAlso <http://dbpedia.org/resource/Gunshot> .


### PR DESCRIPTION
sometimes between 2 properties of the same subject a full stop `.` instead of a semicolon `;` is present